### PR TITLE
Fix: firstKeyTime set to first keyframe start time

### DIFF
--- a/InspectorSpacetime.jsx
+++ b/InspectorSpacetime.jsx
@@ -468,7 +468,7 @@ function getPropObj(opt_propObj) {
 						duration: prop.keyTime(selKeys[m+1]) - prop.keyTime(selKeys[m]),
 					} );
 				}
-				firstKeyTime = Math.min(firstKeyTime, propCollect[propCollect.length-1].startTime);
+				firstKeyTime = Math.min(firstKeyTime, propCollect[0].startTime);							// set firstKeyTime to first keyframe's start time
 				lastKeyTime = Math.max(lastKeyTime, propCollect[propCollect.length-1].endTime);
 			}
 		}


### PR DESCRIPTION
This is a fix for the firstKeyTime variable. The change sets it as the start time of the first selected keyframe. Originally it was set as the second-to-last selected keyframe's start time which skewed the total duration and delay values.